### PR TITLE
Add option to ignore certain keys via the `ignore_keys` parameter

### DIFF
--- a/test/test_annotations.py
+++ b/test/test_annotations.py
@@ -1,0 +1,27 @@
+import unittest
+
+from with_argparse import with_argparse
+
+
+class IgnoreTest(unittest.TestCase):
+    def test_missing_arg_annotation(self):
+        @with_argparse
+        def wrapper(arg):
+            return arg
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Argument [a-z]+ must have a type annotation in order to be viable for argparse"
+        ):
+            wrapper()
+
+    def test_missing_kwarg_annotation(self):
+        @with_argparse
+        def func(*, arg):
+            return arg
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Argument [a-z]+ must have a type annotation in order to be viable for argparse"
+        ):
+            func()

--- a/test/test_argparse.py
+++ b/test/test_argparse.py
@@ -71,6 +71,21 @@ class ArgparseTestCase(unittest.TestCase):
         with sys_args(value=expect):
             self.assertEqual(wrapper(), outer_set_t(expect))
 
+    def test_unused_cli_input(self):
+        @with_argparse
+        def func(arg: str) -> str:
+            return arg
 
-if __name__ == "__main__":
-    unittest.main()
+        with sys_args(abc="123", arg="42"), self.assertRaises(SystemExit):
+            func()
+
+    def test_duplicate_inputs(self):
+        @with_argparse
+        def func(arg: str) -> str:
+            return arg
+
+        with sys_args(arg="456"):
+            with self.assertRaises(TypeError):
+                func(arg="123")
+            with self.assertRaises(TypeError):
+                func("123")

--- a/test/test_ignore.py
+++ b/test/test_ignore.py
@@ -1,0 +1,55 @@
+import logging
+import unittest
+
+from tools import sys_args
+from with_argparse import with_argparse
+
+logging.basicConfig(
+    level="DEBUG"
+)
+
+
+class IgnoreTest(unittest.TestCase):
+    def test_ignore_single_param(self):
+        @with_argparse(ignore_keys={"arg"})
+        def wrapper(arg: str) -> str:
+            return arg
+
+        self.assertEqual("abc", wrapper("abc"))
+
+    def test_ignore_multi_param(self):
+        @with_argparse(ignore_keys={"arg"})
+        def wrapper(arg: str, inp: str) -> str:
+            return inp + arg
+
+        with self.assertRaises(SystemExit):
+            wrapper(arg="abc")
+        with self.assertRaises(SystemExit):
+            wrapper("abc")
+
+        with sys_args(inp="42"):
+            self.assertEqual("42abc", wrapper(arg="abc"))
+            self.assertEqual("42abc", wrapper("abc"))
+
+    def test_ignore_kwarg_multi_param(self):
+        @with_argparse(ignore_keys={"arg"})
+        def wrapper(inp: str, arg: str) -> str:
+            return arg
+
+        with sys_args(inp="42"):
+            self.assertEqual("value", wrapper("value"))
+            self.assertEqual("value", wrapper(arg="value"))
+
+    def test_kwonly_kwarg_multi_param(self):
+        @with_argparse(ignore_keys={"arg"})
+        def wrapper(*, inp: str, arg: str) -> str:
+            return inp + arg
+
+        with self.assertRaises(SystemExit):
+            wrapper("abc")
+        with self.assertRaises(SystemExit):
+            wrapper(arg="abc")
+
+        with sys_args(inp="a"):
+            self.assertEqual("ab", wrapper("b"))
+            self.assertEqual("ab", wrapper(arg="b"))

--- a/with_argparse/impl.py
+++ b/with_argparse/impl.py
@@ -52,6 +52,7 @@ def set_config(key: str, state: bool):
 @overload
 def with_argparse(
     *,
+    ignore_keys: Optional[set[str]] = None,
     ignore_mapping: Optional[set[str]] = None,
     setup_cwd: Optional[bool] = None,
     aliases: Optional[Mapping[str, list[str]]] = None,
@@ -61,11 +62,12 @@ def with_argparse(
 ) -> Callable[[Callable[P, T]], Callable[[], T]]: ...
 
 @overload
-def with_argparse(func: Callable[P, T]) -> Callable[[], T]: ...
+def with_argparse(func: Callable[P, T], /) -> Callable[[], T]: ...
 
 def with_argparse(
     func=None,
     *,
+    ignore_keys: Optional[set[str]] = None,
     ignore_mapping: Optional[set[str]] = None,
     setup_cwd: Optional[bool] = None,
     aliases: Optional[Mapping[str, list[str]]] = None,
@@ -74,6 +76,7 @@ def with_argparse(
     **kwargs: Callable[[Any], Any]
 ):
     aliases = aliases or dict()
+    ignore_keys = ignore_keys or set()
     ignore_mapping = ignore_mapping or set()
     use_glob = use_glob or set()
     setup_cwd = setup_cwd or False
@@ -99,6 +102,7 @@ def with_argparse(
                 fn,
                 aliases=aliases,
                 ignore_rename=ignore_mapping,
+                ignore_keys=ignore_keys,
                 allow_glob=use_glob,
                 allow_custom=use_custom,
             )


### PR DESCRIPTION
Using `ignore_keys`, one can do the following:

```python3
@with_argparse(ignore_keys={'special_param'})
def func(param1: int, special_param: T):
    pass

func(special_param=123)
```
while special_param will never be part of the argparse object