### PR TITLE
Add custom parse functions. Implement preliminary tests for them as well

### DIFF
--- a/test/test_custom_parse.py
+++ b/test/test_custom_parse.py
@@ -1,0 +1,48 @@
+import logging
+import unittest
+from pathlib import Path
+
+from tools import sys_args
+from with_argparse import with_argparse
+
+logging.basicConfig(
+    level="DEBUG"
+)
+
+
+class CustomParseTest(unittest.TestCase):
+    def test_parse_from_list_of_paths(self):
+        class TestClass:
+            @classmethod
+            def from_string(cls, inp: list[Path]):
+                return TestClass(inp)
+            def __init__(self, *args):
+                self.args = args
+            def values(self):
+                return self.args
+        @with_argparse(use_custom={"value": TestClass.from_string})
+        def wrapper(value: TestClass):
+            return value
+
+        with sys_args(value=[".", "."]):
+            path = Path(".")
+            self.assertEqual(wrapper().values()[0], [path, path])
+
+    def test_parse_class_from_str(self):
+        class TestClass:
+            @classmethod
+            def from_string(cls, inp: str) -> "TestClass":
+                return TestClass(inp, "")
+
+            def __init__(self, inp: str, _: str):
+                self.inp = inp
+
+            def value(self) -> str:
+                return self.inp
+
+        @with_argparse(use_custom={"a": TestClass.from_string})
+        def wrapper(a: TestClass):
+            return a
+
+        with sys_args(a="abc"):
+            self.assertEqual(wrapper().value(), "abc")

--- a/test/tools/override_argv.py
+++ b/test/tools/override_argv.py
@@ -15,7 +15,7 @@ class sys_args:
             if isinstance(value, bool) and not value:
                 continue
             self.args.append("--" + key)
-            if isinstance(value, Iterable):
+            if isinstance(value, Iterable) and not isinstance(value, str):
                 for elem in value:
                     self.args.append(str(elem))
             else:

--- a/with_argparse/impl.py
+++ b/with_argparse/impl.py
@@ -1,7 +1,7 @@
 import functools
 import sys
 import typing
-from typing import Callable, Union, ParamSpec, TypeVar, overload, Optional, Mapping, _SpecialForm
+from typing import Callable, Union, ParamSpec, TypeVar, overload, Optional, Mapping, _SpecialForm, Any
 import warnings
 
 from with_argparse.configure_argparse import WithArgparse
@@ -59,7 +59,8 @@ def with_argparse(
     ignore_mapping: Optional[set[str]] = None,
     setup_cwd: Optional[bool] = None,
     aliases: Optional[Mapping[str, list[str]]] = None,
-    use_glob: Optional[set[str]] = None
+    use_glob: Optional[set[str]] = None,
+    use_custom: Optional[Mapping[str, Callable[[Any], Any]]] = None,
 ) -> Callable[[Callable[P, T]], Callable[[], T]]: ...
 
 
@@ -70,11 +71,13 @@ def with_argparse(
     setup_cwd: Optional[bool] = None,
     aliases: Optional[Mapping[str, list[str]]] = None,
     use_glob: Optional[set[str]] = None,
+    use_custom: Optional[Mapping[str, Callable[[Any], Any]]] = None,
 ):
     aliases = aliases or dict()
     ignore_mapping = ignore_mapping or set()
     use_glob = use_glob or set()
     setup_cwd = setup_cwd or False
+    use_custom = use_custom or dict()
 
     def wrapper(fn):
         @functools.wraps(fn)
@@ -96,6 +99,7 @@ def with_argparse(
                 aliases=aliases,
                 ignore_rename=ignore_mapping,
                 allow_glob=use_glob,
+                allow_custom=use_custom,
             )
             return parser.call(inner_args, inner_kwargs)
         return inner


### PR DESCRIPTION
Changes:
- Added additional field `use_custom` to `with_argparse` that allows configuring custom mappings from the CLI to arbitrary objects via single argument callables of type `Callable[[Any], Any]` (example below). Only requirement is the custom function being type annotated in its (only) input type.
Workaround with additional parameter is necessary as mypy does not allow using functions as type annotations, otherwise we could directly get those from there.
  ```python3
  def min_len(elems: list[Path]) -> int:
    return min(map(len, elems))
  
  @with_argparse(use_custom={"value": min_len})
  def func(value: int):
    return value
  ```
- Added two simple tests to verify the functionality